### PR TITLE
page_size limit and default sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,30 @@ HawatelSearchJobs.configure do |config|
   config.indeed[:api]       = 'api.indeed.com'
   config.indeed[:version]   = '2'
   config.indeed[:publisher] = 'secret-key'
+  config.indeed[:page_size] = 25 # allowed range <1,25>
 
   config.xing[:activated]           = true
   config.xing[:consumer_key]        = 'secret-key'
   config.xing[:consumer_secret]     = 'secret-key'
   config.xing[:oauth_token]         = 'secret-key'
   config.xing[:oauth_token_secret]  = 'secret-key'
+  config.xing[:page_size]           = 25 # allowed range <1,100>
 
   config.reed[:activated] = true
   config.reed[:api]       = 'reed.co.uk/api'
   config.reed[:clientid]  = 'secret-key'
   config.reed[:version]   = '1.0'
+  config.reed[:page_size] = 25 # allowed range <1,100>
 
   config.careerbuilder[:activated]  = true
   config.careerbuilder[:api]        = 'api.careerbuilder.com'
   config.careerbuilder[:clientid]   = 'secret-key'
   config.careerbuilder[:version]    = 'v2'
+  config.careerbuilder[:page_size]  = 25 # allowed range <1,100>
 
   config.careerjet[:activated]   = true
   config.careerjet[:api]         = 'public.api.careerjet.net'
+  config.careerjet[:page_size]   = 25 # allowed range <1,99>
 end
 ```
 
@@ -86,7 +91,8 @@ Instance variable *jobs_table* always has last returned job offers.
   p client.jobs_table
 ```
 
-Each API has a limit of returned records. For consistency, each API returns maximum `25` records.
+Each API has a default limit of returned records. For consistency, each API returns maximum `25` records.
+You can change this behavior by setting page_size option in block of HawatelSearchJobs.configure method.
 
 #### Get next page of job offers
 ```ruby

--- a/lib/hawatel_search_jobs/api/careerbuilder.rb
+++ b/lib/hawatel_search_jobs/api/careerbuilder.rb
@@ -114,8 +114,11 @@ module HawatelSearchJobs
         end
 
         def prepare_conn_string(args)
+          page_size = args[:settings][:page_size].to_s.empty? ? RESULT_LIMIT : args[:settings][:page_size].to_i
+          page_size = RESULT_LIMIT if page_size <= 0 || page_size > 100
+
           conn_string = "https://#{args[:settings][:api]}/#{args[:settings][:version]}/jobsearch?" \
-          "PerPage=#{RESULT_LIMIT}&DeveloperKey=#{args[:settings][:clientid]}&"
+          "PerPage=#{page_size}&OrderBy=Date&DeveloperKey=#{args[:settings][:clientid]}&"
 
           conn_string
         end

--- a/lib/hawatel_search_jobs/api/careerjet.rb
+++ b/lib/hawatel_search_jobs/api/careerjet.rb
@@ -10,6 +10,8 @@ module HawatelSearchJobs
             :company  => ''
         }
 
+        RESULT_LIMIT = 25
+
         # Search jobs based on specified keywords or location
         #
         # @param args [Hash]
@@ -89,11 +91,14 @@ module HawatelSearchJobs
         #
         # @return [String] ready to call URL
         def build_url(args)
-          keywords = args[:query][:keywords] if !args[:query][:keywords].to_s.empty?
-          api_url  = args[:settings][:api]   if !args[:settings][:api].to_s.empty?
+          keywords  = args[:query][:keywords] if !args[:query][:keywords].to_s.empty?
+          api_url   = args[:settings][:api]   if !args[:settings][:api].to_s.empty?
+          page_size = args[:settings][:page_size].to_s.empty? ? RESULT_LIMIT : args[:settings][:page_size].to_i
+          page_size = RESULT_LIMIT if page_size <= 0 || page_size > 99
+
           if keywords && api_url
-            !args[:query][:location].to_s.empty? ? location = args[:query][:location] : location = 'europe'
-            "http://#{api_url}/search?locale_code=US_en&pagesize=25&sort=date&keywords=#{keywords}&location=#{location}&page=1"
+            !args[:query][:location].to_s.empty? ? location = args[:query][:location] : location = 'worldwide'
+            "http://#{api_url}/search?locale_code=US_en&pagesize=#{page_size}&sort=date&keywords=#{keywords}&location=#{location}&page=1"
           end
         end
 

--- a/lib/hawatel_search_jobs/client.rb
+++ b/lib/hawatel_search_jobs/client.rb
@@ -40,7 +40,7 @@ module HawatelSearchJobs
     # Search Jobs by specific criteria
     # @param query [Hash]
     # @option query [String] :keywords
-    # @option query [String] :location
+    # @option query [String] :location not working in Xing API
     # @option query [String] :company not working in Reed API
     # @example
     #       HawatelSearchJobs.configure do |config|
@@ -48,25 +48,30 @@ module HawatelSearchJobs
     #           config.indeed[:api]       = 'api.indeed.com'
     #           config.indeed[:version]   = '2'
     #           config.indeed[:publisher] = 'secret-key'
+    #           config.indeed[:page_size] = 25 # allowed range <1,25>
     #
     #           config.xing[:activated]           = true
     #           config.xing[:consumer_key]        = 'secret-key'
     #           config.xing[:consumer_secret]     = 'secret-key'
     #           config.xing[:oauth_token]         = 'secret-key'
     #           config.xing[:oauth_token_secret]  = 'secret-key'
+    #           config.xing[:page_size]           = 25 # allowed range <1,100>
     #
     #           config.reed[:activated] = true
     #           config.reed[:api]       = 'reed.co.uk/api'
     #           config.reed[:clientid]  = 'secret-key'
     #           config.reed[:version]   = '1.0'
+    #           config.reed[:page_size] = 25 # allowed range <1,100>
     #
     #           config.careerbuilder[:activated]  = true
     #           config.careerbuilder[:api]        = 'api.careerbuilder.com'
     #           config.careerbuilder[:clientid]   = 'secret-key'
     #           config.careerbuilder[:version]    = 'v2'
+    #           config.careerbuilder[:page_size]  = 25 # allowed range <1,100>
     #
     #           config.careerjet[:activated]   = true
     #           config.careerjet[:api]         = 'public.api.careerjet.net'
+    #           config.careerjet[:page_size]   = 25 # allowed range <1,99>
     #         end
     #
     #       client = HawatelSearchJobs::Client.new

--- a/lib/hawatel_search_jobs/version.rb
+++ b/lib/hawatel_search_jobs/version.rb
@@ -1,3 +1,3 @@
 module HawatelSearchJobs
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/careerbuilder_spec.rb
+++ b/spec/careerbuilder_spec.rb
@@ -1,14 +1,18 @@
 require 'spec_helper'
+require 'time'
 
-describe HawatelSearchJobs::Api::Careerbuilder do
+xdescribe HawatelSearchJobs::Api::Careerbuilder do
+  before(:each) do
+    HawatelSearchJobs.configure do |config|
+      config.careerbuilder[:api]      = 'api.careerbuilder.com'
+      config.careerbuilder[:version]  = 'v2'
+      config.careerbuilder[:clientid] = ''
+      config.careerbuilder[:page_size]= 100
+    end
+  end
+
   context 'APIs returned jobs' do
     before(:each) do
-      HawatelSearchJobs.configure do |config|
-        config.careerbuilder[:api]      = 'api.careerbuilder.com'
-        config.careerbuilder[:version]  = 'v2'
-        config.careerbuilder[:clientid] = ''
-      end
-
       @query_api = {:keywords => 'ruby', :location => ''}
       @result = HawatelSearchJobs::Api::Careerbuilder.search(
           :settings => HawatelSearchJobs.careerbuilder,
@@ -18,32 +22,77 @@ describe HawatelSearchJobs::Api::Careerbuilder do
           })
     end
 
-    xit '#search' do
+    it '#search' do
       validate_result(@result, @query_api)
       expect(@result.page).to be >= 0
       expect(@result.last).to be >= 0
     end
 
-    xit '#page' do
+    it '#results ordered by date descending' do
       validate_result(@result, @query_api)
-      page_result = HawatelSearchJobs::Api::Careerbuilder.page({
-                                                                   :settings => HawatelSearchJobs.careerbuilder,
-                                                                   :query_key => @result.key,
-                                                                   :page => 1})
+
+      last_date = nil
+      @result.jobs.each do |job|
+        if !job.date.to_s.empty?
+          if !last_date.nil?
+            expect(convert_date_to_timestamp(job.date)).to be <= last_date
+          end
+          last_date = convert_date_to_timestamp(job.date)
+        end
+      end
+    end
+
+    it '#page' do
+      validate_result(@result, @query_api)
+
+      page_result =
+          HawatelSearchJobs::Api::Careerbuilder.page({
+                                                     :settings => HawatelSearchJobs.careerbuilder,
+                                                     :query_key => @result.key,
+                                                     :page => 1})
       expect(page_result.key).to match(/&PageNumber=2/)
       expect(page_result.page).to be == 1
       expect(page_result.last).to be >= 0
+    end
+
+    it '#count of jobs is the same like page_size' do
+      validate_result(@result, @query_api)
+      expect(@result.jobs.count).to eq(HawatelSearchJobs.careerbuilder[:page_size])
+    end
+
+    it '#next page does not contain last page' do
+      validate_result(@result, @query_api)
+
+      first_page =
+          HawatelSearchJobs::Api::Careerbuilder.page({
+                                                     :settings => HawatelSearchJobs.careerbuilder,
+                                                     :query_key => @result.key,
+                                                     :page => 1})
+      expect(first_page.key).to match(/&PageNumber=2/)
+      expect(first_page.page).to be == 1
+      expect(first_page.last).to be >= 0
+
+      second_page =
+          HawatelSearchJobs::Api::Careerbuilder.page({
+                                                      :settings => HawatelSearchJobs.careerbuilder,
+                                                      :query_key => @result.key,
+                                                      :page => 2})
+
+      expect(second_page.key).to match(/&PageNumber=3/)
+      expect(second_page.page).to be == 2
+      expect(second_page.last).to be >= 0
+
+      first_page.jobs.each do |first_job|
+        second_page.jobs.each do |second_job|
+          expect(first_job.url).not_to eq(second_job.url)
+        end
+      end
+
     end
   end
 
   context 'APIs returned empty table' do
     before(:each) do
-      HawatelSearchJobs.configure do |config|
-        config.careerbuilder[:api]      = 'api.careerbuilder.com'
-        config.careerbuilder[:version]  = 'v2'
-        config.careerbuilder[:clientid] = ''
-      end
-
       @query_api = {:keywords => 'job-not-found-zero-records', :location => 'London'}
       @result = HawatelSearchJobs::Api::Careerbuilder.search(
           :settings => HawatelSearchJobs.careerbuilder,
@@ -53,7 +102,7 @@ describe HawatelSearchJobs::Api::Careerbuilder do
           })
     end
 
-    xit '#search' do
+    it '#search' do
       validate_result(@result, @query_api)
       expect(@result.totalResults).to eq(0)
       expect(@result.page).to be_nil
@@ -61,12 +110,13 @@ describe HawatelSearchJobs::Api::Careerbuilder do
       expect(@result.jobs).to be_nil
     end
 
-    xit '#page' do
+    it '#page' do
       validate_result(@result, @query_api)
-      page_result = HawatelSearchJobs::Api::Careerbuilder.page({
-                                                                   :settings => HawatelSearchJobs.careerbuilder,
-                                                                   :query_key => @result.key,
-                                                                   :page => 1})
+      page_result =
+          HawatelSearchJobs::Api::Careerbuilder.page({
+                                                     :settings => HawatelSearchJobs.careerbuilder,
+                                                     :query_key => @result.key,
+                                                     :page => 1})
       expect(page_result.key).to match(/&PageNumber=2/)
       expect(@result.totalResults).to eq(0)
       expect(@result.page).to be_nil
@@ -84,4 +134,10 @@ describe HawatelSearchJobs::Api::Careerbuilder do
     expect(result.key).to match("Location=#{query_api[:location]}")
     expect(result.key).to match("Keywords=#{query_api[:keywords]}")
   end
+
+  def convert_date_to_timestamp(job_date)
+    date = job_date.split('/')
+    return Time.parse("#{date[2]}-#{date[1]}-#{date[0]}").to_i
+  end
+
 end

--- a/spec/careerjet_spec.rb
+++ b/spec/careerjet_spec.rb
@@ -13,6 +13,7 @@ describe HawatelSearchJobs::Api::CareerJet  do
   before(:each) do
     HawatelSearchJobs.configure do |config|
       config.careerjet[:api]   = 'public.api.careerjet.net'
+      config.careerjet[:page_size] = 99
     end
   end
 
@@ -23,12 +24,29 @@ describe HawatelSearchJobs::Api::CareerJet  do
     expect(result.key).to be_a_kind_of(String)
   end
 
+  it "results ordered by date descending" do
+
+    last_date = nil
+    result.jobs.each do |job|
+      if !job.date.to_s.empty?
+        if !last_date.nil?
+          expect(convert_date_to_timestamp(job.date)).to be <= last_date
+        end
+        last_date = convert_date_to_timestamp(job.date)
+      end
+    end
+  end
+
   it "job attributes from search() result" do
     expect(result.jobs.size).to be > 0
     result.jobs.each do |job|
       expect(job.jobtitle).to be_a_kind_of(String)
       expect(job.url).to include('http')
     end
+  end
+
+  it "count of jobs is the same like page_size" do
+    expect(result.jobs.count).to eq(HawatelSearchJobs.careerjet[:page_size])
   end
 
   it "call page() without page param (default 0)" do
@@ -39,6 +57,21 @@ describe HawatelSearchJobs::Api::CareerJet  do
   it "call page() with specified page" do
     jobs =  HawatelSearchJobs::Api::CareerJet.page({:query_key => result.key, :page => 2})
     expect(jobs.page).to eq(2)
+  end
+
+  it "next page does not contain last page" do
+    jobs_first =  HawatelSearchJobs::Api::CareerJet.page({:query_key => result.key, :page => 2})
+    expect(jobs_first.page).to eq(2)
+
+    jobs_second = HawatelSearchJobs::Api::CareerJet.page({:query_key => result.key, :page => 3})
+    expect(jobs_second.page).to eq(3)
+
+    jobs_first.jobs.each do |first_job|
+      jobs_second.jobs.each do |second_job|
+        expect(first_job.url).not_to eq(second_job.url)
+      end
+    end
+
   end
 
   it "call search() with location param" do
@@ -55,5 +88,11 @@ describe HawatelSearchJobs::Api::CareerJet  do
     expect(location_found).to eq(true)
   end
 
+  private
+
+  def convert_date_to_timestamp(job_date)
+    date = job_date.split('/')
+    return Time.parse("#{date[2]}-#{date[1]}-#{date[0]}").to_i
+  end
 
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,39 +3,51 @@ require 'spec_helper'
 describe HawatelSearchJobs::Client do
   before(:each) do
     HawatelSearchJobs.configure do |config|
-      config.indeed[:activated] = true
+      config.indeed[:activated] = false
       config.indeed[:publisher] = ''
+      config.indeed[:page_size] = 10
 
-      config.xing[:activated] = true
-      config.xing[:consumer_key] = 'd'
+      config.xing[:activated] = false
+      config.xing[:consumer_key] = ''
       config.xing[:consumer_secret] = ''
       config.xing[:oauth_token] = ''
       config.xing[:oauth_token_secret] = ''
+      config.xing[:page_size] = 60
 
-      config.reed[:activated] = true
+      config.reed[:activated] = false
       config.reed[:clientid] = ''
+      config.reed[:page_size] = 40
 
-      config.careerbuilder[:activated]= true
+      config.careerbuilder[:activated]= false
       config.careerbuilder[:clientid] = ''
+      config.careerbuilder[:page_size] = 80
 
       config.careerjet[:activated]   =true
       config.careerjet[:api]   = 'public.api.careerjet.net'
+      config.careerjet[:page_size]   = 70
     end
   end
 
   let(:client) { HawatelSearchJobs::Client.new }
 
-  xit '#search valid data' do
+  it '#search valid data' do
     client.search_jobs({:keywords => 'ruby'})
     valid_jobs_table(client)
   end
 
-  xit '#search count method' do
+  it '#search count method' do
     client.search_jobs({:keywords => 'ruby'})
     expect(client.count).to be_kind_of(Integer)
   end
 
-  xit '#next valid data' do
+  it '#search page size limit' do
+    client.search_jobs({:keywords => 'ruby'})
+    client.jobs_table.each do |provider, result|
+      expect(result.jobs.count).to eq(HawatelSearchJobs.instance_variable_get("@#{provider.to_s}")[:page_size])
+    end
+  end
+
+  it '#next valid data' do
     client.search_jobs({:keywords => 'ruby'})
 
     valid_page_number(0, client)
@@ -45,6 +57,8 @@ describe HawatelSearchJobs::Client do
     valid_page_number(1, client)
     valid_jobs_table(client)
   end
+
+
 
   private
   def valid_jobs_table(client)

--- a/spec/indeed_spec.rb
+++ b/spec/indeed_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
-describe "HawatelSearchJobs::Api::Indeed"  do
+xdescribe "HawatelSearchJobs::Api::Indeed"  do
 
   before(:each) do
     HawatelSearchJobs.configure do |config|
       config.indeed[:api] = 'api.indeed.com'
       config.indeed[:publisher] = ''
+      config.indeed[:page_size] = 20
     end
   end
 
@@ -16,14 +17,14 @@ describe "HawatelSearchJobs::Api::Indeed"  do
         :query    => { :keywords => 'ruby', :company => '' }
     )}
 
-  xit "metadata from search() result" do
+  it "metadata from search() result" do
     expect(result.totalResults).to be_a_kind_of(Integer)
     expect(result.page).to be_a_kind_of(Integer)
     expect(result.last).to be_a_kind_of(Integer)
     expect(result.key).to include("http")
   end
 
-  xit "job attrubutes from search() result" do
+  it "job attrubutes from search() result" do
     expect(result.jobs.size).to be > 0
     result.jobs.each do |job|
       expect(job.jobtitle).to be_a_kind_of(String)
@@ -33,30 +34,65 @@ describe "HawatelSearchJobs::Api::Indeed"  do
     end
   end
 
-  xit "call page() without page param (default 0)" do
-    jobs = HawatelSearchJobs::Api::Indeed.page({:query_key => result.key})
+  it "count of jobs is the same like page_size" do
+    expect(result.jobs.count).to eq(HawatelSearchJobs.indeed[:page_size])
+  end
+
+  it "call page() without page param (default 0)" do
+    jobs = HawatelSearchJobs::Api::Indeed.page({:settings => HawatelSearchJobs.indeed, :query_key => result.key})
     expect(jobs.page).to eq(0)
   end
 
-  xit "call page() with specified page" do
-    jobs = HawatelSearchJobs::Api::Indeed.page({:query_key => result.key, :page => 1})
+  it "call page() with specified page" do
+    jobs = HawatelSearchJobs::Api::Indeed.page({:settings => HawatelSearchJobs.indeed, :query_key => result.key, :page => 1})
     expect(jobs.page).to eq(1)
   end
 
-  xit "call search() with providing location param" do
+  it "next page does not contain last page" do
+    jobs_first = HawatelSearchJobs::Api::Indeed.page({:settings => HawatelSearchJobs.indeed, :query_key => result.key, :page => 1})
+    expect(jobs_first.page).to eq(1)
+
+    jobs_second = HawatelSearchJobs::Api::Indeed.page({:settings => HawatelSearchJobs.indeed, :query_key => result.key, :page => 2})
+    expect(jobs_second.page).to eq(2)
+
+    jobs_first.jobs.each do |first_job|
+      jobs_second.jobs.each do |second_job|
+        expect(first_job.url).not_to eq(second_job.url)
+      end
+    end
+  end
+
+  it "results ordered by date descending" do
+    last_date = nil
+    result.jobs.each do |job|
+      if !job.date.to_s.empty?
+        if !last_date.nil?
+          expect(convert_date_to_timestamp(job.date)).to be <= last_date
+        end
+        last_date = convert_date_to_timestamp(job.date)
+      end
+    end
+  end
+
+  it "call search() with providing location param" do
     result = HawatelSearchJobs::Api::Indeed.search(:settings => HawatelSearchJobs.indeed, :query => {:location => 'US'})
     result.jobs.each do |job|
       expect(job.location).to include("US")
     end
   end
 
-
-  xit "call search() with providing company param" do
+  it "call search() with providing company param" do
     result = HawatelSearchJobs::Api::Indeed.search(:settings => HawatelSearchJobs.indeed, :query => {:company => 'ibm'})
     result.jobs.each do |job|
-      expect(job.company).to eq("IBM")
+      expect(job.company).to match(/IBM/)
     end
   end
 
+  private
+
+  def convert_date_to_timestamp(job_date)
+    date = job_date.split('/')
+    return Time.parse("#{date[2]}-#{date[1]}-#{date[0]}").to_i
+  end
 
 end

--- a/spec/reed_spec.rb
+++ b/spec/reed_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 require 'ostruct'
 
-describe HawatelSearchJobs::Api::Reed do
+xdescribe HawatelSearchJobs::Api::Reed do
+  before(:each) do
+    HawatelSearchJobs.configure do |config|
+      config.reed[:api] = "reed.co.uk/api"
+      config.reed[:clientid] = ''
+      config.reed[:page_size] = 100
+    end
+  end
+
   context 'APIs returned jobs' do
     before(:each) do
-      HawatelSearchJobs.configure do |config|
-        config.reed[:api] = "reed.co.uk/api"
-        config.reed[:clientid] = ''
-      end
-
       @query_api = { :keywords => 'ruby', :location => 'London' }
 
       @result = HawatelSearchJobs::Api::Reed.search(
@@ -19,28 +22,39 @@ describe HawatelSearchJobs::Api::Reed do
           })
     end
 
-    xit '#search' do
+    it '#search' do
       validate_result(@result, @query_api)
       expect(@result.page).to be >= 0
       expect(@result.last).to be >= 0
     end
 
-    xit '#page' do
+    it '#page' do
       validate_result(@result, @query_api)
       page_result = HawatelSearchJobs::Api::Reed.page({:settings => HawatelSearchJobs.reed, :query_key => @result.key, :page => 1})
-      expect(page_result.key).to match(/&resultsToSkip=25/)
+      expect(page_result.key).to match(/&resultsToSkip=#{HawatelSearchJobs.reed[:page_size]}/)
       expect(page_result.page).to eq(1)
       expect(page_result.last).to be >= 0
+    end
+
+    it '#next page does not contain last page' do
+      validate_result(@result, @query_api)
+      page_first = HawatelSearchJobs::Api::Reed.page({:settings => HawatelSearchJobs.reed, :query_key => @result.key, :page => 1})
+      page_second = HawatelSearchJobs::Api::Reed.page({:settings => HawatelSearchJobs.reed, :query_key => @result.key, :page => 2})
+
+      page_first.jobs.each do |first_job|
+        page_second.jobs.each do |second_job|
+          expect(first_job.url).not_to eq(second_job.url)
+        end
+      end
+    end
+
+    it '#count of jobs is the same like page_size' do
+      expect(@result.jobs.count).to eq(HawatelSearchJobs.reed[:page_size])
     end
   end
 
   context 'APIs returned empty table' do
     before(:each) do
-      HawatelSearchJobs.configure do |config|
-        config.reed[:api] = "reed.co.uk/api"
-        config.reed[:clientid] = ''
-      end
-
       @query_api = { :keywords => 'job-not-found-zero-records', :location => 'London' }
 
       @result = HawatelSearchJobs::Api::Reed.search(
@@ -51,17 +65,16 @@ describe HawatelSearchJobs::Api::Reed do
           })
     end
 
-    xit '#search' do
+    it '#search' do
       validate_result(@result, @query_api)
       expect(@result.totalResults).to eq(0)
       expect(@result.page).to be_nil
       expect(@result.last).to be_nil
     end
 
-    xit '#page' do
+    it '#page' do
       validate_result(@result, @query_api)
       page_result = HawatelSearchJobs::Api::Reed.page({:settings => HawatelSearchJobs.reed, :query_key => @result.key, :page => 1})
-      expect(page_result.key).to match(/&resultsToSkip=25/)
       expect(@result.totalResults).to eq(0)
       expect(@result.page).to be_nil
       expect(@result.last).to be_nil

--- a/spec/xing_spec.rb
+++ b/spec/xing_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'xing_api'
 
-describe "HawatelSearchJobs::Api::Xing"  do
+xdescribe "HawatelSearchJobs::Api::Xing"  do
 
   before(:each) do
     HawatelSearchJobs.configure do |config|
@@ -9,6 +9,7 @@ describe "HawatelSearchJobs::Api::Xing"  do
       config.xing[:consumer_secret]    = ''
       config.xing[:oauth_token]        = ''
       config.xing[:oauth_token_secret] = ''
+      config.xing[:page_size]          = 100
     end
   end
 
@@ -19,13 +20,13 @@ describe "HawatelSearchJobs::Api::Xing"  do
       :query    => { :keywords => 'ruby', :company => '' }
   )}
 
-  xit "metadata from search() result" do
+  it "metadata from search() result" do
     expect(result.page).to be_a_kind_of(Integer)
     expect(result.last).to be_a_kind_of(Integer)
     expect(result.totalResults).to be_a_kind_of(Integer)
   end
 
-  xit "job attributes from search() result" do
+  it "job attributes from search() result" do
     result.jobs.each do |job|
       expect(job.jobtitle).to be_a_kind_of(String)
       expect(job.location).to be_a_kind_of(String)
@@ -34,15 +35,33 @@ describe "HawatelSearchJobs::Api::Xing"  do
     end
   end
 
-  xit "call page() without specified page (default 0)" do
-    jobs = HawatelSearchJobs::Api::Xing.page({:query_key => result.key})
+  it "count of jobs is the same like page_size" do
+    expect(result.jobs.count).to eq(HawatelSearchJobs.xing[:page_size])
+  end
+
+  it "call page() without specified page (default 0)" do
+    jobs = HawatelSearchJobs::Api::Xing.page({:settings => HawatelSearchJobs.xing, :query_key => result.key})
     expect(jobs.page).to eq(0)
   end
 
-  xit "call page() with specified page" do
-    jobs = HawatelSearchJobs::Api::Xing.page({:query_key => result.key, :page => 1})
+  it "call page() with specified page" do
+    jobs = HawatelSearchJobs::Api::Xing.page({:settings => HawatelSearchJobs.xing, :query_key => result.key, :page => 1})
     expect(jobs.page).to eq(1)
   end
 
+  it "next page does not contain last page" do
+    jobs_first = HawatelSearchJobs::Api::Xing.page({:settings => HawatelSearchJobs.xing, :query_key => result.key, :page => 1})
+    expect(jobs_first.page).to eq(1)
+
+    jobs_second = HawatelSearchJobs::Api::Xing.page({:settings => HawatelSearchJobs.xing, :query_key => result.key, :page => 2})
+    expect(jobs_second.page).to eq(2)
+
+    jobs_first.jobs.each do |first_job|
+      jobs_second.jobs.each do |second_job|
+        expect(first_job.url).not_to eq(second_job.url)
+      end
+    end
+
+  end
 
 end


### PR DESCRIPTION
- feat page_size - you can set page_size limit in HawatelSearchJobs.configure method. Example of usage in Readme file;
- changed default sorting - in Indeed, Careerbuilder, and CareerJet returned results are sorted by date descending. Unfortunately, Reed and Xing do not have such functionality in their api.
- added a few more specs
- changed default location in CareerJet from europe to worldwide to search more results
